### PR TITLE
Retrieve the missing folia-supported

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,4 +3,5 @@ main: me.gamercoder215.kotlinmc.Spigot
 version: ${project.ext.kotlin_version}
 api-version: 1.13
 author: GamerCoder
+folia-supported: true
 website: ${project.ext.url}


### PR DESCRIPTION
## Info
This PR closes #xxxx.

## Details

Retrieve the missing folia-supported

## Tested Environments

### OS
OS: Win

## Demonstration
This is the previous screenshot, which is not loaded because it does not have folia-supported.

I added it, so Kotlinmc can now load normally.

![image 2024-03-14 202416](https://github.com/GamerCoder215/KotlinMC/assets/153366651/0183c378-dd3b-4a81-b20b-6dc52db1424d)

